### PR TITLE
Upgrade step machinery

### DIFF
--- a/src/senaite/sync/config.py
+++ b/src/senaite/sync/config.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.LIMS
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE and CONTRIBUTING.
+
+PROJECTNAME = "senaite.sync"

--- a/src/senaite/sync/configure.zcml
+++ b/src/senaite/sync/configure.zcml
@@ -1,12 +1,22 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
-    i18n_domain="senaite">
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="senaite.sync">
 
   <five:registerPackage package="." initialize=".initialize"/>
 
   <!-- include packages -->
   <include package=".browser" />
+  <include package=".upgrade"/>
+
+  <!-- Installation Profile -->
+  <genericsetup:registerProfile
+      name="default"
+      title="SENAITE SYNC"
+      directory="profiles/default"
+      description="SENAITE SYNC Extension Profile"
+      provides="Products.GenericSetup.interfaces.EXTENSION"/>
 
   <!-- AT FIELD MANAGERS
        Field level interface to get and set values and get a JSON compatible

--- a/src/senaite/sync/profiles/default/metadata.xml
+++ b/src/senaite/sync/profiles/default/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1.0.0</version>
+  <dependencies>
+      <dependency>profile-senaite.sync:default</dependency>
+  </dependencies>
+</metadata>

--- a/src/senaite/sync/upgrade/__init__.py
+++ b/src/senaite/sync/upgrade/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.SYNC
+#
+# Copyright 2018 by it's authors.
+# Some rights reserved. See LICENSE.rst.

--- a/src/senaite/sync/upgrade/configure.zcml
+++ b/src/senaite/sync/upgrade/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    i18n_domain="senaite.sync">
+
+ <genericsetup:upgradeStep
+        title="Upgrade to SENAITE Sync 1.0.0"
+        source="1000"
+        destination="1.0.0"
+        handler="senaite.sync.upgrade.v01_00_000.upgrade"
+        profile="senaite.sync:default"/>
+
+</configure>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Implement upgrade step machinery for `senaite.sync`.

## Current behavior before PR

Upgrade step machinery was not implemented

## Desired behavior after PR is merged

Upgrade steps can be developed for `senaite.sync`.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
